### PR TITLE
fix: add repository metadata

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -8,5 +8,6 @@
       "extensions": [".scala"],
       "tokenize": "src/tokenizeScala.js"
     }
-  ]
+  ],
+  "repository": "https://github.com/lvce-editor/language-basics-scala"
 }


### PR DESCRIPTION
Adds the canonical GitHub repository URL to extension.json so the extension details view can link to the package source.